### PR TITLE
Fix moar tests

### DIFF
--- a/tests/functional/get_installed_test.py
+++ b/tests/functional/get_installed_test.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import pytest
+
 from testing import run
 from testing import venv_update_script
 
@@ -24,6 +26,7 @@ for p in sorted(p.reqnames(p.pip_get_installed())):
     return out.split()
 
 
+@pytest.mark.usefixtures('pypi_server_with_fallback')
 def test_pip_get_installed(tmpdir):
     tmpdir.chdir()
 

--- a/tests/functional/pip_faster.py
+++ b/tests/functional/pip_faster.py
@@ -33,4 +33,4 @@ def it_installs_stuff(tmpdir):
 
     run(str(venv.join('bin/pip-faster')), 'install', 'pure_python_package')
 
-    assert 'pure-python-package==0.1.0' in pip_freeze(str(venv)).split('\n')
+    assert 'pure-python-package==0.2.0' in pip_freeze(str(venv)).split('\n')


### PR DESCRIPTION
I wasn't sure why `test_pip_get_installed` was installing from github and bitbucket so I just used `pypi_server_with_fallback` and didn't mess with it.
